### PR TITLE
feat: 아이콘 배럴 파일로 경로 정리

### DIFF
--- a/src/task/components/TaskCard/layouts/RectangleTaskCard.tsx
+++ b/src/task/components/TaskCard/layouts/RectangleTaskCard.tsx
@@ -1,6 +1,5 @@
 import BaseCard from '../../common/Card/BaseCard';
-import CheckIcon from '../../common/icons/checkIcon/CheckIcon';
-import MemoIcon from '../../common/icons/memoIcon/MemoIcon';
+import { CheckIcon, MemoIcon } from '../../common/icons';
 import LabelPriority from '../../common/LabelPriority/LabelPriority';
 import { TaskCardProps } from '../TaskCard.types';
 

--- a/src/task/components/TaskCard/layouts/SquareTaskCard.tsx
+++ b/src/task/components/TaskCard/layouts/SquareTaskCard.tsx
@@ -1,6 +1,5 @@
 import BaseCard from '../../common/Card/BaseCard';
-import CheckIcon from '../../common/icons/checkIcon/CheckIcon';
-import MemoIcon from '../../common/icons/memoIcon/MemoIcon';
+import { CheckIcon, MemoIcon } from '../../common/icons';
 import LabelPriority from '../../common/LabelPriority/LabelPriority';
 import { TaskCardProps } from '../TaskCard.types';
 

--- a/src/task/components/TaskCard/layouts/TimelineTaskCard.tsx
+++ b/src/task/components/TaskCard/layouts/TimelineTaskCard.tsx
@@ -1,6 +1,5 @@
 import BaseCard from '../../common/Card/BaseCard';
-import CheckIcon from '../../common/icons/checkIcon/CheckIcon';
-import MemoIcon from '../../common/icons/memoIcon/MemoIcon';
+import { CheckIcon, MemoIcon } from '../../common/icons';
 import LabelPriority from '../../common/LabelPriority/LabelPriority';
 import { TaskCardProps } from '../TaskCard.types';
 

--- a/src/task/components/common/icons/index.ts
+++ b/src/task/components/common/icons/index.ts
@@ -1,0 +1,2 @@
+export { default as MemoIcon } from './memoIcon/MemoIcon';
+export { default as CheckIcon } from './checkIcon/CheckIcon';


### PR DESCRIPTION
CheckIcon과 MemoIcon을 각각의 경로에서 import하던 방식에서, 배럴 파일(index.ts)을 통해 하나의 아이콘 모듈로 통합하여 import 경로를 간결하게 정리했습니다.